### PR TITLE
Fix warning that integration will fail in 2023.3

### DIFF
--- a/custom_components/geo_home/__init__.py
+++ b/custom_components/geo_home/__init__.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # TODO Store an API object for your platforms to access
     # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/geo_home/sensor.py
+++ b/custom_components/geo_home/sensor.py
@@ -155,7 +155,7 @@ class GeoHomeGasPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @property
@@ -183,7 +183,7 @@ class GeoHomeGasStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @property
@@ -244,7 +244,7 @@ class GeoHomeElectricityPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @property
@@ -272,7 +272,7 @@ class GeoHomeElectricityStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @property
@@ -360,12 +360,12 @@ class GeoHomeElectricityPowerSensor(CoordinatorEntity, SensorEntity):
     @property
     def last_reset(self):
         return None
-        
+
 class GeoHomeGasCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
         super().__init__(coordinator)
 
@@ -400,7 +400,7 @@ class GeoHomeElectricityCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
         super().__init__(coordinator)
 

--- a/custom_components/geo_home/sensor.py
+++ b/custom_components/geo_home/sensor.py
@@ -155,7 +155,7 @@ class GeoHomeGasPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @property
@@ -183,7 +183,7 @@ class GeoHomeGasStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP"
 
     @property
@@ -244,7 +244,7 @@ class GeoHomeElectricityPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @property
@@ -272,7 +272,7 @@ class GeoHomeElectricityStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP"
 
     @property
@@ -360,12 +360,12 @@ class GeoHomeElectricityPowerSensor(CoordinatorEntity, SensorEntity):
     @property
     def last_reset(self):
         return None
-
+        
 class GeoHomeGasCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP"
         super().__init__(coordinator)
 
@@ -400,7 +400,7 @@ class GeoHomeElectricityCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "GBP"
         super().__init__(coordinator)
 


### PR DESCRIPTION
In Home Assistant `2023.2` logs there's a new warning `geo_home` will fail in the next Home Assistant release `2023.3`.

This PR fixes this warning by using the same [async fix from HACS](https://patch-diff.githubusercontent.com/raw/hacs/integration/pull/3038.diff).

```python
WARNING

Logger: homeassistant.helpers.frame
Source: helpers/frame.py:77
First occurred: 12:14:52 (1 occurrences)
Last logged: 12:14:52

Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for geo_home using this method at custom_components/geo_home/__init__.py, line 19: hass.config_entries.async_setup_platforms(entry, PLATFORMS)
```