### PR TITLE
Enable Home Assistant long term statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+custom_components/geo_home/__pycache__

--- a/custom_components/geo_home/manifest.json
+++ b/custom_components/geo_home/manifest.json
@@ -1,9 +1,7 @@
 {
   "domain": "geo_home",
   "name": "Geo Home",
-  "codeowners": [
-    "@mmillmor"
-  ],
+  "codeowners": ["@mmillmor"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/geo_home",
@@ -12,6 +10,6 @@
   "issue_tracker": "https://github.com/mmillmor/geo_home_hacs/issues",
   "requirements": [],
   "ssdp": [],
-  "version":"1.11.0",
+  "version": "1.11.1",
   "zeroconf": []
 }

--- a/custom_components/geo_home/sensor.py
+++ b/custom_components/geo_home/sensor.py
@@ -98,6 +98,7 @@ class GeoHomeElectricityCreditRemaining(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @callback
@@ -134,6 +135,7 @@ class GeoHomeGasCreditRemaining(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @callback
@@ -163,13 +165,14 @@ class GeoHomeGasCreditRemaining(CoordinatorEntity, SensorEntity):
 
     @property
     def last_reset(self):
-        return None   
+        return None
 
 class GeoHomeElectricityEmergencyCreditBalance(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @callback
@@ -206,6 +209,7 @@ class GeoHomeGasEmergencyCreditBalance(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP"
 
     @callback
@@ -235,7 +239,7 @@ class GeoHomeGasEmergencyCreditBalance(CoordinatorEntity, SensorEntity):
 
     @property
     def last_reset(self):
-        return None    
+        return None
 
 class GeoHomeElectricitySupplyStatus(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
@@ -276,7 +280,7 @@ class GeoHomeElectricitySupplyStatus(CoordinatorEntity, BinarySensorEntity):
                 return "mdi:flash"
             else :
                 return "mdi:flash-outline"
-        return "mdi:flash-off-outline"   
+        return "mdi:flash-off-outline"
 
 class GeoHomeGasSupplyStatus(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
@@ -317,7 +321,7 @@ class GeoHomeGasSupplyStatus(CoordinatorEntity, BinarySensorEntity):
                 return "mdi:fire"
             else :
                 return "mdi:fire-off"
-        return "mdi:fire-alert" 
+        return "mdi:fire-alert"
 
 class GeoHomeGasSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
@@ -398,6 +402,7 @@ class GeoHomeGasPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @callback
@@ -430,6 +435,7 @@ class GeoHomeGasStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/day"
 
     @callback
@@ -500,6 +506,7 @@ class GeoHomeElectricityPriceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/kWh"
 
     @callback
@@ -532,6 +539,7 @@ class GeoHomeElectricityStandingChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/day"
 
     @callback
@@ -639,6 +647,7 @@ class GeoHomeGasCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/hour"
         super().__init__(coordinator)
 
@@ -678,6 +687,7 @@ class GeoHomeElectricityCostPerHourSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: CoordinatorEntity, hub: GeoHomeHub):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "GBP/hour"
         super().__init__(coordinator)
 


### PR DESCRIPTION
Home Assistant 2023.12 added long term statistics to the history graphs.

Out of the box this worked with most of the Geo Home statistics, however a couple of them were missing an `_attr_state_class` which is required for recording long term statistics, so these statistics were lost after the default data retention period (defaults to 10 days).

Note that long term statistics only starts recording from the moment that a sensor has these 3 attributes (device_class, state_class, native_unit_of_measurement), so it will take around 10 days for the long term statistics to start appearing (which I've been testing on my install).

Before:

![Screenshot from 2023-12-22 09-25-49](https://github.com/mmillmor/geo_home/assets/144435/d427f963-d79b-4be0-873a-16da1da537d6)

After:

![Screenshot from 2023-12-22 09-25-13](https://github.com/mmillmor/geo_home/assets/144435/de9009ee-0cf3-4eb5-8759-eca1a24c7558)
