### PR TITLE
Fix Home Assistant deprecation warnings

### DIFF
--- a/custom_components/geo_home/geohome.py
+++ b/custom_components/geo_home/geohome.py
@@ -7,12 +7,6 @@ import time
 import requests
 from requests.auth import HTTPBasicAuth
 
-from homeassistant.components.climate.const import (
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_OFF,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-)
 from homeassistant.core import HomeAssistant
 from .const import (
     BASE_URL,
@@ -40,7 +34,7 @@ class GeoHomeHub:
         self.electricityEmergencyCreditBalance = None
         self.gasEmergencyCreditBalance = None
         self.electricitySupplyStatus = None
-        self.gasSupplyStatus = None			
+        self.gasSupplyStatus = None
         self.electricityReading = None
         self.gasReading = None
         self.gaskWhReading = None
@@ -146,7 +140,7 @@ class GeoHomeHub:
               for remainingItem in remainingArray:
                   if remainingItem["commodityType"] == "ELECTRICITY":
                       if remainingItem["valueAvailable"]:
-                      	  self.electricityCreditRemaining = round(remainingItem["creditBalance"]/100,2)
+                          self.electricityCreditRemaining = round(remainingItem["creditBalance"]/100,2)
                   if remainingItem["commodityType"] == "GAS_ENERGY":
                       if remainingItem["valueAvailable"]:
                           self.gasCreditRemaining = round(remainingItem["creditBalance"]/100,2)
@@ -158,7 +152,7 @@ class GeoHomeHub:
               for EMCItem in EMCArray:
                   if EMCItem["commodityType"] == "ELECTRICITY":
                       if EMCItem["valueAvailable"]:
-                      	  self.electricityEmergencyCreditBalance = round(EMCItem["emergencyCreditBalance"]/100,2)
+                          self.electricityEmergencyCreditBalance = round(EMCItem["emergencyCreditBalance"]/100,2)
                   if EMCItem["commodityType"] == "GAS_ENERGY":
                       if EMCItem["valueAvailable"]:
                           self.gasEmergencyCreditBalance = round(EMCItem["emergencyCreditBalance"]/100,2)

--- a/custom_components/geo_home/manifest.json
+++ b/custom_components/geo_home/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/mmillmor/geo_home_hacs/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "1.11.1",
+  "version": "1.12.0",
   "zeroconf": []
 }

--- a/custom_components/geo_home/sensor.py
+++ b/custom_components/geo_home/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass
 )
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT, STATE_OFF, STATE_ON, VOLUME_CUBIC_METERS
+from homeassistant.const import STATE_OFF, STATE_ON, UnitOfEnergy, UnitOfPower, UnitOfVolume
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -328,7 +328,7 @@ class GeoHomeGasSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -365,7 +365,7 @@ class GeoHomeGasM3Sensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.GAS
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = VOLUME_CUBIC_METERS
+        self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
         super().__init__(coordinator)
 
     @callback
@@ -469,7 +469,7 @@ class GeoHomeElectricitySensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -573,7 +573,7 @@ class GeoHomeGasPowerSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = POWER_WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         super().__init__(coordinator)
 
     @callback
@@ -611,7 +611,7 @@ class GeoHomeElectricityPowerSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = POWER_WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         super().__init__(coordinator)
 
     @callback
@@ -1041,7 +1041,7 @@ class GeoHomeGaskWhTodaySensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -1079,7 +1079,7 @@ class GeoHomeGaskWhThisWeekSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -1119,7 +1119,7 @@ class GeoHomeGaskWhThisMonthSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -1156,7 +1156,7 @@ class GeoHomeElectricitykWhTodaySensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -1194,7 +1194,7 @@ class GeoHomeElectricitykWhThisWeekSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback
@@ -1234,7 +1234,7 @@ class GeoHomeElectricitykWhThisMonthSensor(CoordinatorEntity, SensorEntity):
         self.hub = hub
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         super().__init__(coordinator)
 
     @callback


### PR DESCRIPTION
The following warnings are currently showing up in the Home Assistant logs, this PR fixes them:

```
2024-01-15 08:59:30.571 WARNING (MainThread) [homeassistant.components.climate.const] CURRENT_HVAC_HEAT was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:30.574 WARNING (MainThread) [homeassistant.components.climate.const] CURRENT_HVAC_OFF was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:30.576 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_HEAT was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:30.579 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_OFF was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:31.094 WARNING (MainThread) [homeassistant.const] ENERGY_KILO_WATT_HOUR was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfEnergy.KILO_WATT_HOUR instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:31.095 WARNING (MainThread) [homeassistant.const] POWER_WATT was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPower.WATT instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
2024-01-15 08:59:31.097 WARNING (MainThread) [homeassistant.const] VOLUME_CUBIC_METERS was used from geo_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfVolume.CUBIC_METERS instead, please create a bug report at https://github.com/mmillmor/geo_home_hacs/issues
```

Fixes #39