### PR TITLE
Configurable polling interval

### DIFF
--- a/custom_components/geo_home/config_flow.py
+++ b/custom_components/geo_home/config_flow.py
@@ -32,12 +32,17 @@ def options_schema(options: dict = None) -> dict:
             default=options.get("password", "password"),
             description="Geo Home web password",
         ): str,
+        vol.Required(
+            "polling_interval",
+            default=options.get("polling_interval", 10),  # Default polling interval of 10 seconds
+            description="Polling interval in seconds",
+        ): int,
     }
 
 
-def new_options(username: str, password: str) -> dict:
+def new_options(username: str, password: str, polling_interval: int) -> dict:
     """Create a standard options object."""
-    return {"username": username, "password": password}
+    return {"username": username, "password": password, "polling_interval": polling_interval}
 
 
 def options_data(user_input: dict) -> dict:
@@ -45,6 +50,7 @@ def options_data(user_input: dict) -> dict:
     return new_options(
         user_input.get("username", ""),
         user_input.get("password", ""),
+        user_input.get("polling_interval", 10),  # Default polling interval of 10 seconds
     )
 
 

--- a/custom_components/geo_home/manifest.json
+++ b/custom_components/geo_home/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/mmillmor/geo_home_hacs/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "1.11.1",
+  "version": "1.12.0",
   "zeroconf": []
 }

--- a/custom_components/geo_home/sensor.py
+++ b/custom_components/geo_home/sensor.py
@@ -31,9 +31,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     username = config_entry.data.get("username")
     password = config_entry.data.get("password")
+    polling_interval = config_entry.data.get("polling_interval")
     hub = GeoHomeHub(username, password, hass)
 
-    coordinator = MyCoordinator(hass, hub)
+    coordinator = MyCoordinator(hass, hub, polling_interval)
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -77,7 +78,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class MyCoordinator(DataUpdateCoordinator):
 
-    def __init__(self, hass, hub):
+    def __init__(self, hass, hub, polling_interval):
         """Initialize my coordinator."""
         super().__init__(
             hass,
@@ -85,7 +86,7 @@ class MyCoordinator(DataUpdateCoordinator):
             # Name of the data. For logging purposes.
             name="geo home sensor",
             # Polling interval. Will only be polled if there are subscribers.
-            update_interval=timedelta(seconds=120),
+            update_interval=timedelta(seconds=polling_interval),
         )
         self.hub = hub
 


### PR DESCRIPTION
The current version of this integration defaults to polling the API once every 120 seconds. This limits the sensor update rate to once every 120s. I couldn't find a way to alter this in the integration so I added a new user configuration parameter to set the polling rate. It defaults to 10 seconds. This is the main reason for the change, my Geo Home unit reports electricity data every 10 seconds so I was missing a lot of transient data with an update rate of 120s. Seems to work as intended but haven't done much testing. I'm not a python dev and this is my first ever pull request so apologies if I've gone about any of it the wrong way. Thanks.